### PR TITLE
feat(infra): Expose Optional Lambda Execution Role Property [CLK-239123]

### DIFF
--- a/docs/interfaces/UploadProps.md
+++ b/docs/interfaces/UploadProps.md
@@ -10,6 +10,7 @@
 - [fileName](UploadProps.md#filename)
 - [path](UploadProps.md#path)
 - [prune](UploadProps.md#prune)
+- [role](UploadProps.md#role)
 
 ## Properties
 
@@ -50,3 +51,15 @@ Whether or not to clear out the destination directory before uploading.
 **`Default`**
 
 false
+
+___
+
+### role
+
+• `Optional` `Readonly` **role**: `IRole`
+
+Used as the Lambda Execution Role for the BucketDeployment.
+
+**`Default`**
+
+- role is created automatically by the Construct

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,4 +1,5 @@
 import Ajv, { SchemaObject } from 'ajv';
+import { IRole } from 'aws-cdk-lib/aws-iam';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
@@ -29,6 +30,11 @@ export interface UploadProps {
    * @default false
    */
   readonly prune?: boolean;
+  /**
+   * Used as the Lambda Execution Role for the BucketDeployment.
+   * @default - role is created automatically by the Construct
+   */
+  readonly role?: IRole;
 }
 
 export interface SerializerProps {
@@ -152,6 +158,7 @@ export class Generator extends Construct {
       destinationKeyPrefix: this._uploadProps.path,
       sources: [Source.jsonData(this._uploadProps.fileName, contents)],
       prune: this._uploadProps.prune ?? false,
+      role: this._uploadProps.role,
     });
   }
 }

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -102,11 +102,7 @@ describe('Generator', () => {
       const lambdaId = Object.keys(lambda)[0];
       // Verify BucketDeployment uses the Lambda with role set
       template.hasResourceProperties('Custom::CDKBucketDeployment', {
-        ServiceToken: {
-          'Fn::GetAtt': [lambdaId, 'Arn'],
-        },
-        DestinationBucketKeyPrefix: actualProps.upload.path,
-        DestinationBucketName: actualProps.upload.bucketArn.split(':').pop(),
+        ServiceToken: { 'Fn::GetAtt': [lambdaId, 'Arn'] },
       });
       // Verify Lambda uses the role
       const roleId = stack.getLogicalId(testRole.node.defaultChild as CfnElement);


### PR DESCRIPTION
- feat: Introduce optional `role` property that gets set as the BucketDeployment's Lambda execution role. Default behavior of automatic role creation still applies when `role` is `undefined`.