### PR TITLE
feat(infra): Allow $data References in Ajv Schemas [CLK-245035]

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -3,6 +3,11 @@ import { IRole } from 'aws-cdk-lib/aws-iam';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
+
+// $data fields in schemas allow us to set conditional permitted values.
+// For example, if we have two numbers `num1` and `num2`, where `num2` cannot
+// exceed `num1`, we can use a `$data` reference to enforce that.
+// See test/resources/test.schema.ts `testLessThanTest2` for an example.
 const ajv = new Ajv({ $data: true });
 
 export enum GeneratorFileType {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -3,7 +3,7 @@ import { IRole } from 'aws-cdk-lib/aws-iam';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
-const ajv = new Ajv();
+const ajv = new Ajv({ $data: true });
 
 export enum GeneratorFileType {
   JSON = 'generator_json',

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -31,6 +31,7 @@ describe('Generator', () => {
       { test: false, test1: true, testComplex: { foo: 'buildee', arr: [1] } },
       { test: false, test1: true, testComplex: { arr: [1] } },
       { test: false, test1: true, testComplex: { yield: 'no', arr: [1] } }, // additionalProperties allowed here
+      { test: false, test1: true, test2: 2, testLessThanTest2: 2, testComplex: { arr: [1] } }, // testLessThanTest2 is less than test2
     ];
 
     const testCasesShouldFail = [
@@ -41,6 +42,7 @@ describe('Generator', () => {
       { test: false, test1: true, testComplex: { arr: [1, 2, 3] } },
       { test: false, test1: true, notInSchema: 'correct', testComplex: { arr: [1, 2, 3] } },
       { test: false, test1: true, test2: true, testComplex: { arr: [1] } }, // additionalProperties NOT allowed here
+      { test: false, test1: true, test2: 2, testLessThanTest2: 3, testComplex: { arr: [1] } }, // testLessThanTest2 is GREATER than test2
     ];
 
     test.each(testCasesShouldSucceed)('validateFileContents succeeds properly', (testContents) => {

--- a/test/resources/test.schema.ts
+++ b/test/resources/test.schema.ts
@@ -3,6 +3,8 @@ import { JSONSchemaType } from 'ajv';
 interface Schema {
   test: boolean;
   test1: boolean;
+  test2?: number;
+  testLessThanTest2?: number;
   testComplex: { foo?: string; arr: number[] };
 }
 
@@ -31,6 +33,15 @@ export const schema: JSONSchemaType<Schema> = {
     },
     test1: {
       type: 'boolean',
+    },
+    test2: {
+      type: 'integer',
+      nullable: true,
+    },
+    testLessThanTest2: {
+      type: 'integer',
+      nullable: true,
+      maximum: { $data: '1/test2' } as unknown as number,
     },
     testComplex: objSchema,
   },


### PR DESCRIPTION
We can utilize `$data` in Ajv references to set conditional permitted values. For example, if we have two numbers `num1` and `num2`, where `num2` cannot exceed `num1`, we can use a `$data` reference to make that happen real-time.