### PR TITLE
feat(infra): Expose BucketDeploymentProps.retainOnDelete [CLK-255746]

### DIFF
--- a/docs/interfaces/UploadProps.md
+++ b/docs/interfaces/UploadProps.md
@@ -10,6 +10,7 @@
 - [fileName](UploadProps.md#filename)
 - [path](UploadProps.md#path)
 - [prune](UploadProps.md#prune)
+- [retainOnDelete](UploadProps.md#retainondelete)
 - [role](UploadProps.md#role)
 
 ## Properties
@@ -51,6 +52,25 @@ Whether or not to clear out the destination directory before uploading.
 **`Default`**
 
 false
+
+___
+
+### retainOnDelete
+
+• `Optional` `Readonly` **retainOnDelete**: `boolean`
+
+Whether or not to delete the objects from the bucket when this resource
+is deleted/updated from the stack.
+
+NOTE: Changing the logical ID of the `BucketDeployment` construct, without changing the destination
+(for example due to refactoring, or intentional ID change) **will result in the deletion of the objects**.
+This is because CloudFormation will first create the new resource, which will have no affect,
+followed by a deletion of the old resource, which will cause a deletion of the objects,
+since the destination hasn't changed, and `retainOnDelete` is `false`.
+
+**`Default`**
+
+true
 
 ___
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -36,6 +36,19 @@ export interface UploadProps {
    */
   readonly prune?: boolean;
   /**
+   * Whether or not to delete the objects from the bucket when this resource
+   * is deleted/updated from the stack.
+   *
+   * NOTE: Changing the logical ID of the `BucketDeployment` construct, without changing the destination
+   * (for example due to refactoring, or intentional ID change) **will result in the deletion of the objects**.
+   * This is because CloudFormation will first create the new resource, which will have no affect,
+   * followed by a deletion of the old resource, which will cause a deletion of the objects,
+   * since the destination hasn't changed, and `retainOnDelete` is `false`.
+   *
+   * @default true
+   */
+  readonly retainOnDelete?: boolean;
+  /**
    * Used as the Lambda Execution Role for the BucketDeployment.
    * @default - role is created automatically by the Construct
    */
@@ -163,6 +176,7 @@ export class Generator extends Construct {
       destinationKeyPrefix: this._uploadProps.path,
       sources: [Source.jsonData(this._uploadProps.fileName, contents)],
       prune: this._uploadProps.prune ?? false,
+      retainOnDelete: this._uploadProps.retainOnDelete,
       role: this._uploadProps.role,
     });
   }


### PR DESCRIPTION
Allows the option to toggle whether or not objects are retained on resource update/deletion.